### PR TITLE
I've added a setting to prevent sync from creating new users

### DIFF
--- a/app/views/settings/_ldap_sync_settings.html.erb
+++ b/app/views/settings/_ldap_sync_settings.html.erb
@@ -33,6 +33,8 @@
 
         <p><%= ldap_check_box ldap.name, 'create_groups', :default => true %></p>
 
+        <p><%= ldap_check_box ldap.name, 'create_users', :default => true %></p>
+
         <p><%= ldap_check_box ldap.name, 'sync_user_attributes' %></p>
 
         <p><%= ldap_multiselect ldap.name, 'attributes_to_sync', ['firstname', 'lastname', 'mail'], :size => 15 %></p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -12,6 +12,7 @@ de:
   field_redmine_ldap_sync_must_be_member_of: "Users must be members of"
   field_redmine_ldap_sync_add_to_group: "Add users to group"
   field_redmine_ldap_sync_create_groups: "Create new groups"
+  field_redmine_ldap_sync_create_users: "Create new users"
   field_redmine_ldap_sync_sync_user_attributes: "Sync users attributes"
   field_redmine_ldap_sync_attributes_to_sync: "Attributes to be synced"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
   field_redmine_ldap_sync_must_be_member_of: "Users must be members of"
   field_redmine_ldap_sync_add_to_group: "Add users to group"
   field_redmine_ldap_sync_create_groups: "Create new groups"
+  field_redmine_ldap_sync_create_users: "Create new users"
   field_redmine_ldap_sync_sync_user_attributes: "Sync users attributes"
   field_redmine_ldap_sync_attributes_to_sync: "Attributes to be synced"
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -12,6 +12,7 @@ es:
   field_redmine_ldap_sync_must_be_member_of: "Usuarios deben ser miembros de"
   field_redmine_ldap_sync_add_to_group: "Añadir usuarios al grupo"
   field_redmine_ldap_sync_create_groups: "Crear nuevos grupos"
+  field_redmine_ldap_sync_create_users: "Crear nuevos usuarios"
   field_redmine_ldap_sync_sync_user_attributes: "Sincronizar usuarios"
   field_redmine_ldap_sync_attributes_to_sync: "Atributos que se sincronizan"
 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -12,6 +12,7 @@ pt:
   field_redmine_ldap_sync_must_be_member_of: "Devem ser membros de"
   field_redmine_ldap_sync_add_to_group: "Adicionar ao grupo"
   field_redmine_ldap_sync_create_groups: "Criar novos grupos"
+  field_redmine_ldap_sync_create_users: "Criar novos utilizadores"
   field_redmine_ldap_sync_sync_user_attributes: "Actualizar dados"
   field_redmine_ldap_sync_attributes_to_sync: "Campos a actualizar"
 

--- a/db/migrate/201108021245_change_settings_name.rb
+++ b/db/migrate/201108021245_change_settings_name.rb
@@ -11,6 +11,7 @@ class ChangeSettingsName < ActiveRecord::Migration
         settings[:add_to_group] = settings.delete(:domain_group)
         settings[:groupname_pattern] = settings.delete(:groupname_filter)
         settings[:create_groups] = true
+        settings[:create_users] = true
         settings[:sync_user_attributes] = false
         settings[:attr_member] = 'member'
         settings[:class_group] = 'group'


### PR DESCRIPTION
I like this plugin a lot. However I wanted a way of preventing users from being created in redmine in a sync.

Also users were not being added to the default group in a sync or login (only on create)

For what it is worth, I've added these features but I'm not very fluent in Ruby.
