### PR TITLE
Access auth_source_ldap instead of auth_source in ldap_setting.rb

### DIFF
--- a/app/models/ldap_setting.rb
+++ b/app/models/ldap_setting.rb
@@ -185,7 +185,7 @@ class LdapSetting
   end
 
   def ldap_filter
-    auth_source.send :ldap_filter
+    auth_source_ldap.send :ldap_filter
   end
 
   # Creates a new ldap setting for the given ldap authentication source


### PR DESCRIPTION
Adding an LDAP filter to the auth source causes fatal errors on sync with the following stack trace: 

```
undefined local variable or method `auth_source' for #<LdapSetting:0x00000005030ef8>
/var/lib/gems/2.1.0/gems/activemodel-3.2.19/lib/active_model/attribute_methods.rb:407:in `method_missing'
/opt/redmine/plugins/redmine_ldap_sync/app/models/ldap_setting.rb:188:in `ldap_filter'
/opt/redmine/plugins/redmine_ldap_sync/lib/ldap_sync/entity_manager.rb:287:in `find_all_users'
/opt/redmine/plugins/redmine_ldap_sync/lib/ldap_sync/entity_manager.rb:81:in `block in ldap_users'
/opt/redmine/plugins/redmine_ldap_sync/lib/ldap_sync/entity_manager.rb:341:in `with_ldap_connection'
/opt/redmine/plugins/redmine_ldap_sync/lib/ldap_sync/entity_manager.rb:77:in `ldap_users'
/opt/redmine/plugins/redmine_ldap_sync/lib/ldap_sync/infectors/auth_source_ldap.rb:64:in `block in sync_users'
/opt/redmine/plugins/redmine_ldap_sync/lib/ldap_sync/entity_manager.rb:351:in `block in with_ldap_connection'
/var/lib/gems/2.1.0/gems/net-ldap-0.3.1/lib/net/ldap.rb:564:in `open'
/opt/redmine/plugins/redmine_ldap_sync/lib/ldap_sync/entity_manager.rb:349:in `with_ldap_connection'
/opt/redmine/plugins/redmine_ldap_sync/lib/ldap_sync/infectors/auth_source_ldap.rb:63:in `sync_users'
/opt/redmine/plugins/redmine_ldap_sync/lib/tasks/ldap_sync.rake:30:in `block (5 levels) in <top (required)>'
/opt/redmine/plugins/redmine_ldap_sync/lib/tasks/ldap_sync.rake:28:in `each'
/opt/redmine/plugins/redmine_ldap_sync/lib/tasks/ldap_sync.rake:28:in `block (4 levels) in <top (required)>'
```

Changing auth_source to auth_source_ldap fixes the issue.  This is tested on Redmine 2.5.3.  