### PR TITLE
Use separate DN for nested groups, add option not to create such groups

### DIFF
--- a/app/models/ldap_setting.rb
+++ b/app/models/ldap_setting.rb
@@ -28,9 +28,9 @@ class LdapSetting
   # LDAP_DESCRIPTORS
   LDAP_ATTRIBUTES = %w( groupname member user_memberid user_groups groupid parent_group primary_group group_parentid member_group group_memberid account_flags )
   CLASS_NAMES = %w( class_user class_group )
-  FLAGS = %w( create_groups create_users active )
+  FLAGS = %w( create_groups create_users active create_nested_groups )
   COMBOS = %w( group_membership nested_groups sync_on_login dyngroups users_search_scope )
-  OTHERS = %w( account_locked_test user_fields_to_sync group_fields_to_sync user_ldap_attrs group_ldap_attrs fixed_group admin_group required_group group_search_filter groupname_pattern groups_base_dn dyngroups_cache_ttl )
+  OTHERS = %w( account_locked_test user_fields_to_sync group_fields_to_sync user_ldap_attrs group_ldap_attrs fixed_group admin_group required_group group_search_filter groupname_pattern groups_base_dn dyngroups_cache_ttl nested_groups_base_dn )
 
   validates_presence_of :auth_source_ldap_id
   validates_presence_of :class_user, :class_group, :groupname

--- a/app/views/ldap_settings/_ldap_settings.html.erb
+++ b/app/views/ldap_settings/_ldap_settings.html.erb
@@ -13,6 +13,7 @@
   <p><%= f.text_field :account_locked_test, :size => 50 %></p>
   <p><%= f.select :group_membership, options_for_group_membeship %></p>
   <p><%= f.select :nested_groups, options_for_nested_groups %></p>
+  <p><%= f.text_field :nested_groups_base_dn, :size => 50 %></p>
 
   <fieldset class="box" id="ldap_attributes">
     <legend><%=l(:label_attribute_plural)%></legend>

--- a/app/views/ldap_settings/_synchronization_actions.html.erb
+++ b/app/views/ldap_settings/_synchronization_actions.html.erb
@@ -7,6 +7,7 @@
   <p><%= f.text_field :fixed_group, :size => 15  %></p>
   <p><%= f.check_box :create_users %></p>
   <p><%= f.check_box :create_groups %></p>
+  <p><%= f.check_box :create_nested_groups %></p>
   <p><%= f.select :dyngroups, options_for_dyngroups %>
     <span id="dyngroups-cache-ttl"><%= f.text_field :dyngroups_cache_ttl, :required => true, :size => 5 %> <%= l(:label_minutes) %></span>
   </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,12 +35,14 @@ en:
 
   field_nested_groups: "Nested groups"
   field_create_groups: "Create groups"
+  field_create_nested_groups: "Create nested groups"
   field_create_users: "Create users"
   field_sync_on_login: "Synchronize on login"
   field_dyngroups: "Dynamic groups"
   field_dyngroups_cache_ttl: "Cache TTL"
 
   field_groups_base_dn: "Groups base DN"
+  field_nested_groups_base_dn: "Nested groups base DN"
   field_group_membership: "Group membership"
   field_class_user: "Users objectclass"
   field_users_search_scope: "Users search scope"

--- a/lib/ldap_sync/infectors/auth_source_ldap.rb
+++ b/lib/ldap_sync/infectors/auth_source_ldap.rb
@@ -164,7 +164,13 @@ module LdapSync::Infectors::AuthSourceLdap
         end
 
         changes = groups_changes(user)
-        added = changes[:added].map {|g| find_or_create_group(g).first }.compact
+        added = changes[:added].map {|g|
+          if setting.create_nested_groups?
+            find_or_create_group(g).first
+          else
+            ::Group.where("LOWER(lastname) = ?", g.mb_chars.downcase).first
+          end
+        }.compact
         user.groups << added unless added.empty?
 
         deleted_groups = changes[:deleted].map {|g| g.mb_chars.downcase }


### PR DESCRIPTION
If subgroups are under different DN (comparing to main groups), the plugin fails to fetch them. `nil` as 'Groups base DN' doesn't help here either.

So, in this fork I solved this issue (#205) by:

- Introducing 'Nested groups base DN', which is used only for subgroups.
- New option 'Create nested groups', which controls, whether subgroups are imported into Redmine.

Regarding the latter:

The plugin always creates all groups, the user belongs to. But, when importing users, who belong to subgroups, we may not want such groups to be imported (such users are also added to the corresponding main group). Therefore, I added 'Create nested groups', that allows to control this.

_Thanks @acosonic for the idea._